### PR TITLE
後方互換性を維持する

### DIFF
--- a/app/controllers/work_time_infos_controller.rb
+++ b/app/controllers/work_time_infos_controller.rb
@@ -1,14 +1,9 @@
 class WorkTimeInfosController < ApplicationController
-  before_action :require_sign_in
-
   def show
-    @wti = WorkTimeInfo.find(current_user.code)
-    return redirect_to edit_user_registration_path if @wti.std_work_days == 0
-  end
-
-  private
-
-  def require_sign_in
-    redirect_to new_user_session_path unless user_signed_in?
+    @wti = WorkTimeInfo.find(params[:code])
+    
+    # 誤ったコードが入力された時にどうするかを考えないといけない
+    # そもそも Deprecated なものなのでそこまで考える必要は無い気もする
+    # return redirect_to edit_user_registration_path if @wti.std_work_days == 0
   end
 end

--- a/app/controllers/work_times_controller.rb
+++ b/app/controllers/work_times_controller.rb
@@ -1,0 +1,14 @@
+class WorkTimesController < ApplicationController
+  before_action :require_sign_in
+
+  def show
+    @wti = WorkTimeInfo.find(current_user.code)
+    return redirect_to edit_user_registration_path if @wti.std_work_days == 0
+  end
+
+  private
+
+  def require_sign_in
+    redirect_to new_user_session_path unless user_signed_in?
+  end
+end

--- a/app/views/work_time_infos/show.html.slim
+++ b/app/views/work_time_infos/show.html.slim
@@ -23,8 +23,8 @@
         td 1日あたり何時間働けばいいか
         td = WorkTimeInfo.to_time(@wti.required_work_times)
 
-  a.button href="/work_time_info?code=#{params[:code]}"
-    | Reload
+  = link_to work_time_info_path(code: params[:code]) do
+    button.button Reload
 
   hr
 

--- a/app/views/work_times/show.html.slim
+++ b/app/views/work_times/show.html.slim
@@ -1,0 +1,62 @@
+.content
+  h2 Work time informations
+
+  table.table.is-striped
+    tbody
+      tr
+        td 所定労働時間
+        td = WorkTimeInfo.to_time(@wti.std_work_hours)
+  
+      tr
+        td 今までの実質労働時間
+        td = WorkTimeInfo.to_time(@wti.excess_work_times)
+  
+      tr
+        td 今月の残り出勤日数
+        td = "#{@wti.remain_work_days} 日"
+        
+      tr
+        td 貯金
+        td = WorkTimeInfo.to_time(@wti.work_time_margin)
+
+      tr
+        td 1日あたり何時間働けばいいか
+        td = WorkTimeInfo.to_time(@wti.required_work_times)
+
+  a.button href="/work_time_info?code=#{params[:code]}"
+    | Reload
+
+  hr
+
+  h2 解説
+
+  p
+    | 全体を通して、勤務中に数値を確認すると一部の数値が本来ありえないように見える数値になることがあります。
+    br
+    | 退勤後に確認することで正しい（？）数値を確認できます。
+
+  h3 所定労働時間
+  p
+    | 今月働かなければいけない時間数です。今月の労働日数に8をかけたものになります。
+
+  h3 今までの実質労働時間
+  p
+    | このページを開いた時点までで働いた時間です。
+    br
+    | 実際の労働時間に、全休1回につき8時間、半休1回につき4時間が加算されたものです。
+
+  h3 貯金
+  p
+    | このページを開いた時点までの標準的な労働時間に対して、どれだけ余分に働いているかを表します。
+    br
+    | 所定労働日数から残りの出勤可能日数を引き、それに8をかけたものが標準的な労働時間になります。
+    br
+    | これまでの実質労働時間から標準的な労働時間を引いたものが貯金になります。
+    br
+    | ※ 勤務中に見ると大きくマイナスになることがあります。
+  
+  h3 1日あたり何時間働けばいいか
+  p
+    | 貯金を残りの勤務日数で等分し、1日あたりどれだけ働けばいいかを示します。
+    br
+    | ※ 貯金と同じく、勤務中に見ると値が意図しないものになることがあります。

--- a/app/views/work_times/show.html.slim
+++ b/app/views/work_times/show.html.slim
@@ -23,8 +23,8 @@
         td 1日あたり何時間働けばいいか
         td = WorkTimeInfo.to_time(@wti.required_work_times)
 
-  a.button href="/work_time_info?code=#{params[:code]}"
-    | Reload
+  = link_to root_path do
+    button.button Reload
 
   hr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   resource :work_time_info, only: [:show]
+  resource :work_time, only: [:show]
 
-  root 'work_time_infos#show'
+  root 'work_times#show'
 end

--- a/spec/requests/work_time_infos_spec.rb
+++ b/spec/requests/work_time_infos_spec.rb
@@ -11,61 +11,43 @@ RSpec.describe 'WorkTimeInfos', type: :request do
     stub_request(:get, "#{Rails.application.secrets.base_url}/attendance")
   end
 
-  subject { get work_time_info_path }
+  subject { get work_time_info_path(code: code) }
 
   describe '#show' do
-    context 'ログイン済みのとき' do
-      let!(:user) { FactoryGirl.create(:user, code: code) }
-      before { login_as user }
+    context '正常なコードの場合' do
+      before do
+        allow_any_instance_of(WorkTimeInfo).
+          to receive(:std_work_days).
+          and_return(20)
+        
+        allow_any_instance_of(WorkTimeInfo).
+          to receive(:worked_days).
+          and_return(15)
+        
+        allow_any_instance_of(WorkTimeInfo).
+          to receive(:worked_hours).
+          and_return(120.0)
 
-      context '正常なコードの場合' do
-        before do
-          allow_any_instance_of(WorkTimeInfo).
-            to receive(:std_work_days).
-            and_return(20)
-          
-          allow_any_instance_of(WorkTimeInfo).
-            to receive(:worked_days).
-            and_return(15)
-          
-          allow_any_instance_of(WorkTimeInfo).
-            to receive(:worked_hours).
-            and_return(120.0)
+        allow_any_instance_of(WorkTimeInfo).
+          to receive(:salaried_days).
+          and_return(1)
 
-          allow_any_instance_of(WorkTimeInfo).
-            to receive(:salaried_days).
-            and_return(1)
-
-          allow_any_instance_of(WorkTimeInfo).
-            to receive(:half_salaried_days).
-            and_return(1.5)
-        end
-
-        it 'ステータスコード200を返す' do
-          subject
-          expect(response).to have_http_status(:ok)
-        end
-
-        it '勤務表ページを取得する' do
-          subject
-          expect(get_attendance_page_stub).to have_been_requested
-        end
+        allow_any_instance_of(WorkTimeInfo).
+          to receive(:half_salaried_days).
+          and_return(1.5)
       end
 
-      context '不正なコードの場合' do
-        it 'コードの編集ページにリダイレクトする' do
-          subject
-          expect(response).to redirect_to(edit_user_registration_path)
-        end
-      end
-    end
-
-    context '未ログインのとき' do
-      it 'ログインページにリダイレクトする' do
+      it 'ステータスコード200を返す' do
         subject
-        expect(response).to have_http_status(302)
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '勤務表ページを取得する' do
+        subject
+        expect(get_attendance_page_stub).to have_been_requested
       end
     end
+
+    context '不正なコードの場合'
   end
 end

--- a/spec/requests/work_times_spec.rb
+++ b/spec/requests/work_times_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'WorkTimes', type: :request do
+  let(:code) { 'test_code' }
+
+  let!(:get_top_page_stub) do
+    stub_request(:get, Rails.application.secrets.base_url).with(query: { code: code })
+  end
+
+  let!(:get_attendance_page_stub) do
+    stub_request(:get, "#{Rails.application.secrets.base_url}/attendance")
+  end
+
+  subject { get work_time_info_path }
+
+  describe '#show' do
+    context 'ログイン済みのとき' do
+      let!(:user) { FactoryGirl.create(:user, code: code) }
+      before { login_as user }
+
+      context '正常なコードの場合' do
+        before do
+          allow_any_instance_of(WorkTimeInfo).
+            to receive(:std_work_days).
+            and_return(20)
+          
+          allow_any_instance_of(WorkTimeInfo).
+            to receive(:worked_days).
+            and_return(15)
+          
+          allow_any_instance_of(WorkTimeInfo).
+            to receive(:worked_hours).
+            and_return(120.0)
+
+          allow_any_instance_of(WorkTimeInfo).
+            to receive(:salaried_days).
+            and_return(1)
+
+          allow_any_instance_of(WorkTimeInfo).
+            to receive(:half_salaried_days).
+            and_return(1.5)
+        end
+
+        it 'ステータスコード200を返す' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it '勤務表ページを取得する' do
+          subject
+          expect(get_attendance_page_stub).to have_been_requested
+        end
+      end
+
+      context '不正なコードの場合' do
+        it 'コードの編集ページにリダイレクトする' do
+          subject
+          expect(response).to redirect_to(edit_user_registration_path)
+        end
+      end
+    end
+
+    context '未ログインのとき' do
+      it 'ログインページにリダイレクトする' do
+        subject
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/work_times_spec.rb
+++ b/spec/requests/work_times_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'WorkTimes', type: :request do
     stub_request(:get, "#{Rails.application.secrets.base_url}/attendance")
   end
 
-  subject { get work_time_info_path }
+  subject { get work_time_path }
 
   describe '#show' do
     context 'ログイン済みのとき' do

--- a/spec/routing/home_routing_spec.rb
+++ b/spec/routing/home_routing_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe HomeController, type: :routing do
   describe 'GET /' do
     it do
-      expect(get: '/').to route_to(controller: "work_time_infos", action: "show")
+      expect(get: '/').to route_to(controller: "work_times", action: "show")
     end
   end
 end

--- a/spec/routing/work_times_routing_spec.rb
+++ b/spec/routing/work_times_routing_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe WorkTimesController, type: :routing do
+  describe 'GET /work_time' do
+    it do
+      expect(get: '/work_time').
+        to route_to(controller: 'work_times', action: 'show')
+    end
+  end
+end


### PR DESCRIPTION
### やりたかったこと

ログイン無し、従来のページで閲覧している人向けに、後方互換性を保つため work_time_info?code= も使えるようにしたい。


### やったこと

- 要ログインの仕組みを `/work_time` に変更
- `work_time_info?code=` を今までと同じようにログイン不要で使えるようにした


### やってないこと

- 後方互換維持用のページの例外処理は考えていない