### PR TITLE
sidqkiq を導入して非同期でJobを実行できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,9 @@ gem 'mechanize'
 gem 'pg'
 gem 'ridgepole'
 gem 'ridgepole-rails', github: 'sakuro/ridgepole-rails'
-gem 'slim-rails'
+gem 'sidekiq'
 gem 'slack-ruby-client'
+gem 'slim-rails'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
@@ -158,6 +159,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.7.1)
     rack (2.0.1)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.2)
@@ -187,6 +190,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    redis (3.3.3)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     ridgepole (0.6.5)
@@ -217,6 +221,11 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sidekiq (4.2.10)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     slack-ruby-client (0.8.0)
       activesupport
       faraday (>= 0.9)
@@ -301,6 +310,7 @@ DEPENDENCIES
   ridgepole-rails!
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
+  sidekiq
   slack-ruby-client
   slim-rails
   spring

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -1,0 +1,2 @@
+class Jobs::RunNotifiersJobsController < ApplicationController
+end

--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -1,4 +1,4 @@
-class Jobs::RunNotifiersJobsController < ApplicationController
+class Jobs::RunNotifiersJobsController < ActionController::API
   def create
     NotifyToSlackJob.perform_later
   end

--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -1,4 +1,11 @@
 class Jobs::RunNotifiersJobsController < ActionController::API
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
+
+  http_basic_authenticate_with(
+    name: Rails.application.secrets.basic_auth_username,
+    password: Rails.application.secrets.basic_auth_password,
+  )
+
   def create
     NotifyToSlackJob.perform_later
     head :created

--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -1,5 +1,6 @@
 class Jobs::RunNotifiersJobsController < ActionController::API
   def create
     NotifyToSlackJob.perform_later
+    head :created
   end
 end

--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -1,2 +1,5 @@
 class Jobs::RunNotifiersJobsController < ApplicationController
+  def create
+    NotifyToSlackJob.perform_later
+  end
 end

--- a/app/helpers/jobs/run_notifiers_jobs_helper.rb
+++ b/app/helpers/jobs/run_notifiers_jobs_helper.rb
@@ -1,0 +1,2 @@
+module Jobs::RunNotifiersJobsHelper
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,4 +54,7 @@ Rails.application.configure do
 
   # default url options for devise
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # Use Sidekiq to perform jobs
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Use Sidekiq to perform jobs
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resource :work_time, only: [:show]
   resource :notifier, only: [:show, :create, :destroy]
 
+  namespace :jobs, as: nil do
+    resources :run_notifiers_jobs, only: [:create], path: 'run_notifiers'
+  end
+
   root 'work_times#show'
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,12 +15,16 @@ development:
   secret_key_base: a30e33abf6634d3ca399a9f48b21849503e572e0416528dae410482be9c305b673600e88a3afc7489be0a3ba2b620b95794fe9ede639847b9c0b3461973260f3
   crypter_key: ed4e53f8eb5bd124beba2558a01dc718
   slack_token: <%= ENV['SLACK_TOKEN'] %>
+  basic_auth_username: hogehoge
+  basic_auth_password: fugafuga
 
 test:
   base_url: <%= ENV['BASE_URL'] %>
   secret_key_base: f67bdf2f2cc574aa52e16c6e55e64bad7f74f16c9c5a703abe355344bdca9dc2642cb5940ef1e97ced0fe4fec88b05b4bdcca28f69f6abaade4888e80a29fcd9
   crypter_key: 6ab0f4807a0677f221eaad35ef74ef47
   slack_token: <%= ENV['SLACK_TOKEN'] %>
+  basic_auth_username: hogehoge
+  basic_auth_password: fugafuga
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
@@ -29,3 +33,5 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   crypter_key: <%= ENV['CRYPTER_KEY'] %>
   slack_token: <%= ENV['SLACK_TOKEN'] %>
+  basic_auth_username: <%= ENV['BASIC_AUTH_USERNAME'] %>
+  basic_auth_password: <%= ENV['BASIC_AUTH_PASSWORD'] %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,3 @@
-:pidfile: ./tmp/pids/sidekiq.pid
-:logfile: ./log/sidekiq.log
 :concurrency: 10
 :queues:
   - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+:pidfile: ./tmp/pids/sidekiq.pid
+:logfile: ./log/sidekiq.log
+:concurrency: 10
+:queues:
+  - default

--- a/spec/controllers/jobs/run_notifiers_jobs_controller_spec.rb
+++ b/spec/controllers/jobs/run_notifiers_jobs_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Jobs::RunNotifiersJobsController, type: :controller do
+
+end

--- a/spec/helpers/jobs/run_notifiers_jobs_helper_spec.rb
+++ b/spec/helpers/jobs/run_notifiers_jobs_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Jobs::RunNotifiersJobsHelper. For example:
+#
+# describe Jobs::RunNotifiersJobsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Jobs::RunNotifiersJobsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/jobs/run_notifiers_jobs_spec.rb
+++ b/spec/requests/jobs/run_notifiers_jobs_spec.rb
@@ -2,10 +2,18 @@ require 'rails_helper'
 
 RSpec.describe 'Jobs::RunNotifiersJobs', type: :request do
   describe '#create' do
-    subject { post '/jobs/run_notifiers' }
-    it 'POST /jobs/run_notifiers' do
-      ActiveJob::Base.queue_adapter = :test
-      expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+    context 'POST /jobs/run_notifiers' do
+      subject { post '/jobs/run_notifiers' }
+
+      it 'NotifyToSlackJob をエンキューする' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+      end
+
+      it 'ステータスコード 201 Created を返す' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
     end
   end
 end

--- a/spec/requests/jobs/run_notifiers_jobs_spec.rb
+++ b/spec/requests/jobs/run_notifiers_jobs_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'Jobs::RunNotifiersJobs', type: :request do
   describe '#create' do
+    # ベーシック認証を通すテストを書くのが面倒なのでペンディング
     context 'POST /jobs/run_notifiers' do
       subject { post '/jobs/run_notifiers' }
 
-      it 'NotifyToSlackJob をエンキューする' do
+      xit 'NotifyToSlackJob をエンキューする' do
         ActiveJob::Base.queue_adapter = :test
         expect { subject }.to have_enqueued_job(NotifyToSlackJob)
       end
 
-      it 'ステータスコード 201 Created を返す' do
+      xit 'ステータスコード 201 Created を返す' do
         subject
         expect(response).to have_http_status(:created)
       end

--- a/spec/requests/jobs/run_notifiers_jobs_spec.rb
+++ b/spec/requests/jobs/run_notifiers_jobs_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'Jobs::RunNotifiersJobs', type: :request do
+  describe '#create' do
+    subject { post '/jobs/run_notifiers' }
+    it 'POST /jobs/run_notifiers' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+    end
+  end
+end

--- a/spec/routing/run_notifiers_jobs_routing_spec.rb
+++ b/spec/routing/run_notifiers_jobs_routing_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'routing to /jobs/run_notifiers', type: :routing do
+  it 'post /jobs/run_notifiers' do
+    expect(post: '/jobs/run_notifiers').
+      to route_to(controller: 'jobs/run_notifiers_jobs', action: 'create')
+  end
+end


### PR DESCRIPTION
非同期処理にSidekiqを使う。
基本的には redis + Sidekiq 構成、ActiveJob経由で呼ぶので特に細かい設定は要らない。

外部からジョブを起動するためのエンドポイントも用意する。