### PR TITLE
RunNotifierJob を用意してユーザごとに別々の Slack 通知 Job を起動する

### DIFF
--- a/app/controllers/jobs/run_notifiers_jobs_controller.rb
+++ b/app/controllers/jobs/run_notifiers_jobs_controller.rb
@@ -7,7 +7,7 @@ class Jobs::RunNotifiersJobsController < ActionController::API
   )
 
   def create
-    NotifyToSlackJob.perform_later
+    RunNotifiersJob.perform_later
     head :created
   end
 end

--- a/app/jobs/notify_to_slack_job.rb
+++ b/app/jobs/notify_to_slack_job.rb
@@ -1,16 +1,15 @@
 class NotifyToSlackJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    notifiers = Notifier.all
+  def perform(notifier_id)
+    notifier = Notifier.find(notifier_id)
 
     client = Slack::Web::Client.new(token: Rails.application.secrets.slack_token)
 
-    notifiers.each do |n|
-      work_time_info = WorkTimeInfo.find(n.user.code) 
-      return if work_time_info.std_work_days == 0
+    work_time_info = WorkTimeInfo.find(notifier.user.code) 
+    return if work_time_info.std_work_days == 0
 
-      text = <<-EOS
+    text = <<-EOS
 :clock10: #{Time.now.strftime('%Y年%m月%d日')} の勤怠情報
 
 所定労働時間
@@ -29,7 +28,6 @@ class NotifyToSlackJob < ApplicationJob
 #{WorkTimeInfo.to_time(work_time_info.required_work_times)}
 EOS
 
-      client.chat_postMessage(channel: "@#{n.slack_user_name}", text: text)
-    end
+    client.chat_postMessage(channel: "@#{notifier.slack_user_name}", text: text)
   end
 end

--- a/app/jobs/run_notifiers_job.rb
+++ b/app/jobs/run_notifiers_job.rb
@@ -1,0 +1,7 @@
+class RunNotifiersJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
+end

--- a/app/jobs/run_notifiers_job.rb
+++ b/app/jobs/run_notifiers_job.rb
@@ -2,6 +2,8 @@ class RunNotifiersJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
+    return if Time.now.wday == 6 || Time.now.wday == 0
+
     Notifier.all.each do |notifier|
       NotifyToSlackJob.perform_later(notifier.id)
     end

--- a/app/jobs/run_notifiers_job.rb
+++ b/app/jobs/run_notifiers_job.rb
@@ -1,7 +1,9 @@
 class RunNotifiersJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    NotifyToSlackJob.perform_later
+  def perform(*_args)
+    Notifier.all.each do |notifier|
+      NotifyToSlackJob.perform_later(notifier.id)
+    end
   end
 end

--- a/app/jobs/run_notifiers_job.rb
+++ b/app/jobs/run_notifiers_job.rb
@@ -2,6 +2,6 @@ class RunNotifiersJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    # Do something later
+    NotifyToSlackJob.perform_later
   end
 end

--- a/spec/jobs/notify_to_slack_job_spec.rb
+++ b/spec/jobs/notify_to_slack_job_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe NotifyToSlackJob, type: :job do
         and_return(1.5)
     end
 
-    subject { NotifyToSlackJob.perform_now }
+    subject { NotifyToSlackJob.perform_now(notifier.id) }
 
-    it 'Notifier を登録しているユーザに Slack の IM を送る' do
+    it '指定されたNotifier ID のユーザに Slack の IM を送る' do
       subject
       expect(slack_postMessage_stub).to have_been_requested
     end

--- a/spec/jobs/run_notifiers_job_spec.rb
+++ b/spec/jobs/run_notifiers_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RunNotifiersJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/jobs/run_notifiers_job_spec.rb
+++ b/spec/jobs/run_notifiers_job_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe RunNotifiersJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#perform' do
+    subject { RunNotifiersJob.perform_now }
+
+    it 'NotifyToSlackJob をエンキューする' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+    end
+  end
 end

--- a/spec/jobs/run_notifiers_job_spec.rb
+++ b/spec/jobs/run_notifiers_job_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe RunNotifiersJob, type: :job do
   describe '#perform' do
+    let!(:notifier_1) { FactoryGirl.create(:notifier, slack_user_name: 'notifier1') }
+
     subject { RunNotifiersJob.perform_now }
 
     it 'NotifyToSlackJob をエンキューする' do
       ActiveJob::Base.queue_adapter = :test
-      expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+      expect { subject }.to have_enqueued_job(NotifyToSlackJob).with(notifier_1.id)
     end
   end
 end

--- a/spec/jobs/run_notifiers_job_spec.rb
+++ b/spec/jobs/run_notifiers_job_spec.rb
@@ -6,9 +6,22 @@ RSpec.describe RunNotifiersJob, type: :job do
 
     subject { RunNotifiersJob.perform_now }
 
-    it 'NotifyToSlackJob をエンキューする' do
-      ActiveJob::Base.queue_adapter = :test
-      expect { subject }.to have_enqueued_job(NotifyToSlackJob).with(notifier_1.id)
+    context '平日の場合' do
+      before { travel_to '2017-04-07 00:00:00 JST' }
+
+      it 'NotifyToSlackJob をエンキューする' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { subject }.to have_enqueued_job(NotifyToSlackJob).with(notifier_1.id)
+      end
+    end
+
+    context '土日の場合' do
+      before { travel_to '2017-04-08 09:00:01 JST' }
+
+      it 'NotifyToSlackJob をエンキューしない' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { subject }.not_to have_enqueued_job(NotifyToSlackJob)
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   
   config.include Warden::Test::Helpers
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/jobs/run_notifiers_jobs_spec.rb
+++ b/spec/requests/jobs/run_notifiers_jobs_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'Jobs::RunNotifiersJobs', type: :request do
     context 'POST /jobs/run_notifiers' do
       subject { post '/jobs/run_notifiers' }
 
-      xit 'NotifyToSlackJob をエンキューする' do
+      xit 'RunNotifiersJob をエンキューする' do
         ActiveJob::Base.queue_adapter = :test
-        expect { subject }.to have_enqueued_job(NotifyToSlackJob)
+        expect { subject }.to have_enqueued_job(RunNotifiersJob)
       end
 
       xit 'ステータスコード 201 Created を返す' do


### PR DESCRIPTION
ひとつのJob内で全ユーザの情報取得、通知をやっていたのでそれをやめた。

RunNotifiersJobを用意し、それを叩くと各ユーザごとに独立したjobを作ってSlack通知を処理するようにした。